### PR TITLE
Fix choosing locale

### DIFF
--- a/app/helpers/locales_helper.rb
+++ b/app/helpers/locales_helper.rb
@@ -11,7 +11,9 @@ module LocalesHelper
     content_tag :div, :class => 'locales_chooser' do
       form_tag my_locale_url, :method => :put do
         Setting.available_languages.collect do |language|
-          styled_button_tag language, name: 'locale', value: language
+          styled_button_tag I18n.t('general_lang_name', locale: language),
+                            name: 'locale',
+                            value: language
         end.join(" ").html_safe +
         hidden_field_tag(:back_url, request.url)
       end


### PR DESCRIPTION
## Description

Choosing the locale was broken during restyling, because the `value` got lost.

I took the liberty to display an actual language name, because that seems to be more apropriate than: `de`, `en`, `fr` and even longer ISO language codes...
